### PR TITLE
Updated Newton.Json to 13.0.2 and RestSharp to 106.15.0

### DIFF
--- a/modules/swagger-codegen/src/main/resources/csharp/Project.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/Project.mustache
@@ -67,13 +67,13 @@
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml" />
     <Reference Include="Newtonsoft.Json">
-      <HintPath Condition="Exists('$(SolutionDir)\packages')">$(SolutionDir)\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath Condition="Exists('$(SolutionDir)\packages')">$(SolutionDir)\packages\Newtonsoft.Json.13.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="JsonSubTypes">
       <HintPath Condition="Exists('$(SolutionDir)\packages')">$(SolutionDir)\packages\JsonSubTypes.1.2.0\lib\net46\JsonSubTypes.dll</HintPath>
     </Reference>
     <Reference Include="RestSharp">
-      <HintPath Condition="Exists('$(SolutionDir)\packages')">$(SolutionDir)\packages\RestSharp.106.2.2\lib\net452\RestSharp.dll</HintPath>
+      <HintPath Condition="Exists('$(SolutionDir)\packages')">$(SolutionDir)\packages\RestSharp.106.15.0\lib\net452\RestSharp.dll</HintPath>
     </Reference>
     {{#generatePropertyChanged}}
     <Reference Include="PropertyChanged">

--- a/modules/swagger-codegen/src/main/resources/csharp/compile.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/compile.mustache
@@ -15,9 +15,9 @@ if not exist ".\nuget.exe" powershell -Command "(new-object System.Net.WebClient
 
 if not exist ".\bin" mkdir bin
 
-copy packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll bin\Newtonsoft.Json.dll
+copy packages\Newtonsoft.Json.13.0.2\lib\net45\Newtonsoft.Json.dll bin\Newtonsoft.Json.dll
 copy packages\JsonSubTypes.1.2.0\lib\net46\JsonSubTypes.dll bin\JsonSubTypes.dll
-copy packages\RestSharp.106.2.2\lib\net452\RestSharp.dll bin\RestSharp.dll
+copy packages\RestSharp.106.15.0\lib\net452\RestSharp.dll bin\RestSharp.dll
 {{#generatePropertyChanged}}
 copy packages\Fody.1.29.4\Fody.dll bin\Fody.dll
 copy packages\PropertyChanged.Fody.1.51.3\PropertyChanged.Fody.dll bin\PropertyChanged.Fody.dll

--- a/modules/swagger-codegen/src/main/resources/csharp/nuspec.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/nuspec.mustache
@@ -30,9 +30,9 @@
         <!-- Dependencies are automatically installed when the package is installed -->
         <dependencies>
 
-            <dependency id="NewtonSoft.Json" version="12.0.3" />
+            <dependency id="NewtonSoft.Json" version="13.0.2" />
             <dependency id="JsonSubTypes" version="1.2.0" />
-            <dependency id="RestSharp" version="106.2.2" />
+            <dependency id="RestSharp" version="106.15.0" />
             {{#generatePropertyChanged}}
             <dependency id="Fody" version="1.29.4" />
             <dependency id="PropertyChanged.Fody" version="1.51.3" />

--- a/modules/swagger-codegen/src/main/resources/csharp/packages.config.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/packages.config.mustache
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="RestSharp" version="106.2.2" targetFramework="net462" developmentDependency="true" />
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net462" developmentDependency="true" />
+  <package id="RestSharp" version="106.15.0" targetFramework="net462" developmentDependency="true" />
+  <package id="Newtonsoft.Json" version="13.0.2" targetFramework="net462" developmentDependency="true" />
   <package id="JsonSubTypes" version="1.2.0" targetFramework="net462" developmentDependency="true" />
   {{#generatePropertyChanged}}
   <package id="Fody" version="1.29.4" targetFramework="{{targetFrameworkNuget}}" developmentDependency="true" />


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

